### PR TITLE
Invalid import fixed.

### DIFF
--- a/img.go
+++ b/img.go
@@ -7,7 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/bmizerany/pat"
-	"github.com/fzzbt/radix/redis"
+	"github.com/fzzy/radix/redis"
 	"io"
 	"io/ioutil"
 	"log"


### PR DESCRIPTION
The command below:
$ go get -u github.com/arnaud-lb/goresize

Will return that:
cd .; git clone https://github.com/fzzbt/radix /Users/user/gopath/src/github.com/fzzbt/radix
Cloning into '/Users/user/gopath/src/github.com/fzzbt/radix'...
remote: Repository not found.
fatal: repository 'https://github.com/fzzbt/radix/' not found
package github.com/fzzbt/radix/redis: exit status 128
